### PR TITLE
A simpler solution to transferProps

### DIFF
--- a/01 - Core/08 - Transferring Props.js
+++ b/01 - Core/08 - Transferring Props.js
@@ -1,8 +1,8 @@
-import { HTML, mergeHTMLProps } from "react-dom";
+import { HTML: JSX } from "react-dom";
 
 // Draft
 
-interface FancyButtonProps extends typeof HTML.button.prototype.props {
+interface FancyButtonProps extends typeof JSX.button.prototype.props {
     color: string,
     width: number,
     height: number
@@ -17,32 +17,55 @@ class FancyButton {
   props: FancyButtonProps; // Could this interface be inlined?
 
   render() {
-    var button = HTML.button(mergeHTMLProps(
-      this.props,
-      {
-        className: 'FancyButton',
-        // The linter analyses this file and notices these references to
-        // props.color, props.width and props.height.
-        style: {
+    // The linter analyses this file and notices these references to
+    // props.color, props.width and props.height.
+
+    // Any consumed property needs to be explicitly overridden so that
+    // they don't accidentally leak down to the parent. We can issue a static
+    // lint warning if these are forgotten. Hence the weird undefined props
+    // below. Unsolved issue: Since this props now have too many unknown keys,
+    // how do we warn for typos?
+
+    var button =
+      <button
+        {...this.props}
+        className+=" FancyButton"
+        style={{
+          ...this.props.style,
           backgroundColor: this.props.color,
           padding: 10,
           width: this.props.width - 10,
           height: this.props.height - 10
-        },
-        // Any consumed property needs to be explicitly overridden so that
-        // they don't accidentally leak down to the parent. Static lint warning
-        // if these are forgotten.
-        color: undefined,
-        width: undefined,
-        height: undefined
-        // Unsolved issue: Since this props now have too many unknown keys, how
-        // do we warn for typos?
-      }
-    ));
+        }}
+        color={undefined}
+        width={undefined}
+        height={undefined}
+      />;
+
+    /**
+     * The spread operator and += in JSX desugars to:
+     *
+     * HTML.button(Object.assign(
+     *   {},
+     *   this.props,
+     *   {
+     *     className: this.props.className + ' FancyButton',
+     *     style: Object.assign({}, this.props.style, {
+     *       backgroundColor: this.props.color,
+     *       padding: 10,
+     *       width: this.props.width - 10,
+     *       height: this.props.height - 10
+     *     }),
+     *     color: undefined,
+     *     width: undefined,
+     *     height: undefined
+     *   }
+     * ));
+    */
 
     /**
      * button.props === {
-     *   className: 'FancyButton test',
+     *   className: 'test FancyButton',
      *   disabled: true,
      *   style: {
      *     backgroundColor: 'blue',


### PR DESCRIPTION
This uses a linter that works on a single file and doesn't need runtime
magic. Unsolved issue: It still passes too much down. How to catch typos?
