### PR TITLE
Small syntax updates to Classes.js

### DIFF
--- a/01 - Core/01 - Classes.js
+++ b/01 - Core/01 - Classes.js
@@ -9,21 +9,21 @@ export class Button extends Component {
   // compatible syntax. Notice the subtle syntax difference between the colon
   // and the equal sign.
   props : {
-    width: number
-  }
+    width: ?number;
+  };
 
   // Default properties can be defined as a static property initializer.
   // The value of each property is shallow copied onto the final props object.
   static defaultProps = {
     width: 100
-  }
+  };
 
   // Initial state is defined using a property initializer. In this simple
   // form it behaves identical to TypeScript. You may refer to this.props
   // within this initializer to make intial state a function of props.
   state = {
     counter: Math.round(this.props.width / 10)
-  }
+  };
 
   // Instead of relying on auto-binding magic inside React, we use a property
   // initializer with an arrow function. This effectively creates a single
@@ -31,7 +31,7 @@ export class Button extends Component {
   handleClick = (event) => {
     event.preventDefault();
     this.setState({ counter: this.state.counter + 1 });
-  }
+  };
 
   // Props and state are passed into render as a convenience to avoid the need
   // for aliasing or referring to `this`.


### PR DESCRIPTION
I'm just playing a little bit with this and there are some interesting syntax bits to consider here.
- Property initializers will all need a semi-colon at the end. I don't think there is a way around that (unless of course you want to rely on ASI) – this does actually complicate auto-binding a little bit and makes it look more foreign to regular class instance methods. Of course, that doesn't prevent anyone from just auto-binding all functions; it might very well become the canonical way of defining all functions within a react class.
- Let's use Flow because it is at this point more expressive than TypeScript. Assuming Flow is more descriptive, the TypeScript version of the same code will just strip out some things. In your example, since you are defining `width` as a default prop, the prop itself should be nullable. Flow also puts semicolons at the end of type definitions in objects.
