### PR TITLE
Use const over let for exports

### DIFF
--- a/09 - Reduce State/01 - Declarative Component Module.js
+++ b/09 - Reduce State/01 - Declarative Component Module.js
@@ -1,6 +1,6 @@
 // Declarative React Component
 
-export default let FancyButton = {
+export default const FancyButton = {
 
   // getInitialState
   initialize(props) {


### PR DESCRIPTION
If ES6+ syntax is to be used, for exports of an object variable that will not change, const is more appropriate.